### PR TITLE
Issue openam#33 Upgrade unit testing frameworks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,14 @@
     <maven.min.version>3.0.1</maven.min.version>
 
     <!-- Third party components versions -->
-    <assertj.version>2.1.0</assertj.version>
+    <assertj.version>3.13.2</assertj.version>
     <fest-assert.version>1.4</fest-assert.version>
     <jackson.version>2.9.7</jackson.version>
     <jackson-databind.version>${jackson.version}</jackson-databind.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.28.2</mockito.version>
     <servlet-api.version>3.1.0</servlet-api.version>
     <slf4j.version>1.7.12</slf4j.version>
-    <testng.version>6.9.4</testng.version>
+    <testng.version>6.14.3</testng.version>
 
     <!-- Shared components versions -->
     <forgerock-commons.version>20.1.1-SNAPSHOT</forgerock-commons.version>
@@ -88,7 +88,7 @@
     <javax-jms-api.version>2.0.1</javax-jms-api.version>
     <glassfish.version>3.1</glassfish.version>
     <rest-assured.version>2.3.0</rest-assured.version>
-    <restito.version>0.5.1</restito.version>
+    <restito.version>0.9.3</restito.version>
     <jmh.version>1.12</jmh.version>
     <apache-httpclient.version>4.4.1</apache-httpclient.version>
     <grizzly.version>2.3.24</grizzly.version>
@@ -103,7 +103,7 @@
     <osgi-wrapped-rhino.version>1.7R4</osgi-wrapped-rhino.version>
 
     <!-- persistit -->
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
 
     <!-- bloomfiltet -->
     <hdrhistogram.version>2.1.4</hdrhistogram.version>
@@ -151,7 +151,7 @@
     <java-ipv6.version>0.14</java-ipv6.version>
     <json.version>20090211</json.version>
     <santuario.xmlsec.version>1.5.6</santuario.xmlsec.version>
-    <powermock.version>1.6.6</powermock.version>
+    <powermock.version>2.0.2</powermock.version>
     <activemq.version>5.13.3</activemq.version>
     <logback.version>1.1.3</logback.version>
     <cxf.version>2.7.18</cxf.version>
@@ -218,7 +218,7 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
@@ -716,6 +716,7 @@
         <groupId>com.xebialabs.restito</groupId>
         <artifactId>restito</artifactId>
         <version>${restito.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
@@ -1256,7 +1257,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.2</version>
+        <version>4.0.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1297,7 +1298,7 @@
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
+        <artifactId>powermock-api-mockito2</artifactId>
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
## Analysis

openam-jp/openam#33

OpenAM uses the following unit testing frameworks.

* TestNG 6.8.5
* AssertJ 2.1.0
* Mockito 1.9.5
* EasyMock 3.2
* Powermock 1.5
* JUnit 4.10

Some frameworks do not support Java 11.
For example, Mockito supports Java 11 from version 2.20.1.


## Solution
Upgrade unit testing frameworks. Then, tests will pass in Java 8 environment.
- TestNG 6.14.3
- AssertJ 3.13.2
- Mockito 2.28.2
- EasyMoch 4.0.2
- PowerMock 2.0.2
- Junit 4.12


## Install/Update
This fix relies on aggregation of dependencies on the BOM.
The unit testing frameworks are updated by BOM.
To apply the fix, get the modules in the following order and build them.

- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam


## Regression testing
Test results from testframework have not changed.
