### PR TITLE
Issue openam#53 Groovy script causes infinite loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <mozilla-rhino.version>1.7R4</mozilla-rhino.version>
-    <groovy.version>2.4.6</groovy.version>
-    <groovy-sandbox.version>1.6</groovy-sandbox.version>
+    <groovy.version>2.4.17</groovy.version>
+    <groovy-sandbox.version>1.9</groovy-sandbox.version>
     <geoip.version>2.0.0</geoip.version>
     <jaxb.version>1.0.6</jaxb.version>
     <jaxb1.version>2.0.2</jaxb1.version>


### PR DESCRIPTION
## Analysis

openam-jp/openam#53 may be due to the following issue with Groovy Sandbox.

* Infinite loop when trying to write a for-loop (Issue 16)
* MissingPropertyException in loop with binding variable (Issue 17)

## Solution

* Update Groovy Sandbox to 1.9 (Groovy is also updated)

## Testing

See openam-jp/openam#167 "Testing"
