### PR TITLE
Issue openam#32 Support Java 11 (OpenJDK 11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <!-- i18n-framework -->
     <maven-project.version>3.0-alpha-2</maven-project.version>
     <maven-plugin.version>3.2.3</maven-plugin.version>
-    <maven-plugin-plugin.version>3.3</maven-plugin-plugin.version>
+    <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
     <!-- guice -->
     <guice.version>3.0</guice.version>
@@ -131,8 +131,10 @@
     <groovy.version>2.4.6</groovy.version>
     <groovy-sandbox.version>1.6</groovy-sandbox.version>
     <geoip.version>2.0.0</geoip.version>
-    <jaxb.version>1.0.6</jaxb.version>
-    <jaxb1.version>2.0.2</jaxb1.version>
+    <jaxb.version>2.3.0</jaxb.version>
+    <jaxb-impl.version>2.2.2</jaxb-impl.version>
+    <jaxb-libs.version>1.0.6</jaxb-libs.version>
+    <jaxb1.version>2.2.5.1</jaxb1.version>
     <jaxrpc-api.version>1.1</jaxrpc-api.version>
     <jaxrpc-impl.version>1.1.3_01</jaxrpc-impl.version>
     <jaxrpc-spi.version>1.1.3_01</jaxrpc-spi.version>
@@ -873,6 +875,24 @@
         <version>${sleepycat-je.version}</version>
       </dependency>
 
+      <!-- opendj -->
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-xjc</artifactId>
+        <version>2.3.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.ws</groupId>
+        <artifactId>jaxws-ri</artifactId>
+        <version>2.3.2</version>
+        <type>pom</type>
+      </dependency>
+
       <!-- openam -->
       <dependency>
         <groupId>org.apache.click</groupId>
@@ -1041,13 +1061,18 @@
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
+        <artifactId>jaxb-core</artifactId>
         <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>${jaxb-impl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-libs</artifactId>
-        <version>${jaxb.version}</version>
+        <version>${jaxb-libs.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
@@ -1383,6 +1408,11 @@
         <groupId>org.apache.cxf.services.sts</groupId>
         <artifactId>cxf-services-sts-core</artifactId>
         <version>${cxf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.ws</groupId>
+        <artifactId>jaxws-api</artifactId>
+        <version>2.3.1</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Analysis
openam-jp/openam#32

OpenAM now supports Java8.

While Java 8 is supported by various vendors, but public updates of Oracle Java will close soon.
Also, since release 9, the release model has changed.

OpenAM needs to support Java 11, the latest long-term support Java version.

## Solution
Support Java 11 (OpenJDK 11) as development environment and execution environment.

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam
