### PR TITLE
 Issue openam#219 Upgrade Jackson library to 2.10.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,9 @@
     <groovy.version>2.4.17</groovy.version>
     <groovy-sandbox.version>1.9</groovy-sandbox.version>
     <geoip.version>2.0.0</geoip.version>
-    <jaxb.version>2.3.0</jaxb.version>
+    <jaxb.version>2.3.2</jaxb.version>
     <jaxb-impl.version>2.2.2</jaxb-impl.version>
+    <jaxb-core.version>2.3.0</jaxb-core.version>
     <jaxb-libs.version>1.0.6</jaxb-libs.version>
     <jaxb1.version>2.2.5.1</jaxb1.version>
     <jaxrpc-api.version>1.1</jaxrpc-api.version>
@@ -1056,8 +1057,8 @@
         <version>${geoip.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
         <version>${jaxb.version}</version>
       </dependency>
       <dependency>
@@ -1068,12 +1069,18 @@
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-core</artifactId>
-        <version>${jaxb.version}</version>
+        <version>${jaxb-core.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
         <version>${jaxb-impl.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
@@ -1425,6 +1432,12 @@
         <groupId>javax.xml.ws</groupId>
         <artifactId>jaxws-api</artifactId>
         <version>2.3.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <apache-rhino.version>1.7R4_1</apache-rhino.version>
     <args4j.version>2.0.16</args4j.version>
     <json-simple.version>1.1</json-simple.version>
-    <javax-mail.version>1.5.1</javax-mail.version>
+    <jakarta-mail.version>1.6.5</jakarta-mail.version>
     <commons-lang3.version>3.4</commons-lang3.version>
     <osgi-wrapped-rhino.version>1.7R4</osgi-wrapped-rhino.version>
 
@@ -788,8 +788,8 @@
       </dependency>
       <dependency>
         <groupId>com.sun.mail</groupId>
-        <artifactId>javax.mail</artifactId>
-        <version>${javax-mail.version}</version>
+        <artifactId>jakarta.mail</artifactId>
+        <version>${jakarta-mail.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1149,6 +1149,12 @@
         <groupId>javax.xml.soap</groupId>
         <artifactId>saaj-api</artifactId>
         <version>${saaj-api.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.messaging.saaj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <!-- Third party components versions -->
     <assertj.version>3.13.2</assertj.version>
     <fest-assert.version>1.4</fest-assert.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.10.4</jackson.version>
     <jackson-databind.version>${jackson.version}</jackson-databind.version>
     <mockito.version>2.28.2</mockito.version>
     <servlet-api.version>3.1.0</servlet-api.version>


### PR DESCRIPTION
## Analysis
openam-jp/openam#217
openam-jp/openam#219

jackson is a parsing library for Cbor.
WebAuthn Authentication module use it and older version has problem in parsing authenticatorData.

and older version has some security Issues from CVE.
*CVE-2019-17267
*CVE-2020-9547
*CVE-2020-10673
*CVE-2020-9548
*CVE-2019-14892

## Solution
Upgrade jackson to 2.10.4.

## Testing
Unit tests works fine.